### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/main/java/org/sagebionetworks/markdown/parsers/DoiAutoLinkParser.java
+++ b/src/main/java/org/sagebionetworks/markdown/parsers/DoiAutoLinkParser.java
@@ -24,7 +24,7 @@ public class DoiAutoLinkParser extends BasicMarkdownElementParser {
 		Matcher m = p.matcher(line.getMarkdown());
 		StringBuffer sb = new StringBuffer();
 		while(m.find()) {
-			String updated = "<a target=\"_blank\" class=\"link\" href=\"http://dx.doi.org/" + m.group(1) + "\">" + m.group(0) +"</a>";
+			String updated = "<a target=\"_blank\" class=\"link\" href=\"https://doi.org/" + m.group(1) + "\">" + m.group(0) +"</a>";
 			
 			extractor.putContainerIdToContent(getCurrentDivID(), updated);
 			

--- a/src/main/java/org/sagebionetworks/markdown/utils/ServerMarkdownUtils.java
+++ b/src/main/java/org/sagebionetworks/markdown/utils/ServerMarkdownUtils.java
@@ -188,7 +188,7 @@ public class ServerMarkdownUtils {
 	}
 	
 	public static String getDoiLink(String fullDoi, String doiName){
-		return "<a target=\"_blank\" class=\"link\" href=\"http://dx.doi.org/" +
+		return "<a target=\"_blank\" class=\"link\" href=\"https://doi.org/" +
 				doiName + "\">" + fullDoi +"</a>";
 	}
 	

--- a/src/test/java/org/sagebionetworks/markdown/SynapseMarkdownProcessorTest.java
+++ b/src/test/java/org/sagebionetworks/markdown/SynapseMarkdownProcessorTest.java
@@ -212,7 +212,7 @@ public class SynapseMarkdownProcessorTest {
 		String result = processor.markdown2Html(testString, null, "");
 		
 		//link should go refer to the doi
-		assertTrue(result.contains("href=\"http://dx.doi.org/"+exampleDoi+"\""));
+		assertTrue(result.contains("href=\"https://doi.org/"+exampleDoi+"\""));
 		//and the text itself should contain "doi"
 		assertTrue(result.contains(">"+exampleDoi+"<"));
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update the code that hyperlinks DOIs.

Cheers!